### PR TITLE
feat: support split specs with $ref pointers and remote URL sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@ A Model Context Protocol (MCP) server that exposes OpenAPI schema information to
 
 ## Features
 
-- Load any OpenAPI schema file (JSON or YAML) specified via command line argument
+- Load OpenAPI schema from a **local file path** or **URL** (JSON or YAML) via command line argument
+- Supports specs split across multiple files with `$ref` pointers (bundled into a single document at load time)
+- Handles circular schema references safely
 - Explore API paths, operations, parameters, and schemas
 - View detailed request and response schemas
 - Look up component definitions and examples
@@ -15,17 +17,19 @@ A Model Context Protocol (MCP) server that exposes OpenAPI schema information to
 
 ### Command Line
 
-Run the MCP server with a specific schema file:
+Run the MCP server with a local schema file or a remote URL:
 
 ```bash
 # Use the default openapi.yaml in current directory
 npx -y mcp-openapi-schema
 
-# Use a specific schema file (relative path)
+# Use a local schema file (relative or absolute path)
 npx -y mcp-openapi-schema ../petstore.json
-
-# Use a specific schema file (absolute path)
 npx -y mcp-openapi-schema /absolute/path/to/api-spec.yaml
+
+# Use a remote schema URL
+npx -y mcp-openapi-schema https://example.com/openapi.yaml
+npx -y mcp-openapi-schema https://petstore3.swagger.io/api/v3/openapi.json
 
 # Show help
 npx -y mcp-openapi-schema --help
@@ -41,6 +45,10 @@ To use this MCP server with Claude Desktop, edit your `claude_desktop_config.jso
     "OpenAPI Schema": {
       "command": "npx",
       "args": ["-y", "mcp-openapi-schema", "/ABSOLUTE/PATH/TO/openapi.yaml"]
+    },
+    "Petstore API (URL)": {
+      "command": "npx",
+      "args": ["-y", "mcp-openapi-schema", "https://petstore3.swagger.io/api/v3/openapi.json"]
     }
   }
 }
@@ -61,8 +69,11 @@ To use this MCP server with Claude Code CLI, follow these steps:
    # Basic syntax
    claude mcp add openapi-schema npx -y mcp-openapi-schema
 
-   # Example with specific schema
+   # Example with local schema file
    claude mcp add petstore-api npx -y mcp-openapi-schema ~/Projects/petstore.yaml
+
+   # Example with remote schema URL
+   claude mcp add petstore-remote npx -y mcp-openapi-schema https://petstore3.swagger.io/api/v3/openapi.json
    ```
 
 2. **Verify the MCP server is registered**
@@ -104,6 +115,8 @@ The server provides the following tools for LLMs to interact with OpenAPI schema
 - `list-security-schemes`: Lists all available security schemes
 - `get-examples`: Gets examples for a specific component or endpoint
 - `search-schema`: Searches across paths, operations, and schemas
+
+**Note on `$ref` pointers**: the schema is bundled at load time, so references to external files are resolved, but cross-references within the document are kept as internal pointers (e.g. `$ref: '#/components/schemas/Pet'`). This keeps responses compact and supports circular references. To expand a pointer, call `get-component` with the referenced name.
 
 ## Examples
 

--- a/example-usage.mjs
+++ b/example-usage.mjs
@@ -7,120 +7,73 @@ import { fileURLToPath } from "url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
-// Set up the MCP client to communicate with our server
-const transport = new StdioClientTransport({
-  command: "node",
-  args: [
-    resolve(__dirname, "index.mjs"),
-    resolve(__dirname, "./sample-petstore.yaml")
-  ],
-});
+let failures = 0;
 
-const client = new Client({
-  name: "openapi-schema-client",
-  version: "1.0.0",
-});
+// Run every tool against the given schema and report failures
+async function runSuite(schemaPath, label) {
+  console.log(`\n========== SUITE: ${label} (${schemaPath}) ==========`);
 
-// Connect to the server
-console.log("Connecting to MCP server...");
-await client.connect(transport);
-console.log("Connected to MCP server successfully!");
-
-// Run example tool calls
-try {
-  // List endpoints
-  console.log("\n--- LISTING ENDPOINTS ---");
-  const endpoints = await client.callTool({
-    name: "list-endpoints",
-    arguments: {},
+  const transport = new StdioClientTransport({
+    command: "node",
+    args: [resolve(__dirname, "index.mjs"), resolve(__dirname, schemaPath)],
   });
-  console.log(endpoints.content[0].text);
 
-  // Get endpoint details
-  console.log("\n--- GET ENDPOINT DETAILS ---");
-  const endpointDetails = await client.callTool({
-    name: "get-endpoint",
-    arguments: {
-      path: "/pets",
-      method: "get",
-    },
+  const client = new Client({
+    name: "openapi-schema-client",
+    version: "1.0.0",
   });
-  console.log(endpointDetails.content[0].text);
 
-  // Get request body schema
-  console.log("\n--- GET REQUEST BODY SCHEMA ---");
-  const requestBody = await client.callTool({
-    name: "get-request-body",
-    arguments: {
-      path: "/pets",
-      method: "post",
-    },
-  });
-  console.log(requestBody.content[0].text);
+  console.log("Connecting to MCP server...");
+  await client.connect(transport);
+  console.log("Connected to MCP server successfully!");
 
-  // List components
-  console.log("\n--- LIST COMPONENTS ---");
-  const components = await client.callTool({
-    name: "list-components",
-    arguments: {},
-  });
-  console.log(components.content[0].text);
+  const calls = [
+    ["LISTING ENDPOINTS", "list-endpoints", {}],
+    ["GET ENDPOINT DETAILS", "get-endpoint", { path: "/pets", method: "get" }],
+    ["GET REQUEST BODY SCHEMA", "get-request-body", { path: "/pets", method: "post" }],
+    ["LIST COMPONENTS", "list-components", {}],
+    ["GET COMPONENT SCHEMA", "get-component", { type: "schemas", name: "Pet" }],
+    ["SEARCH SCHEMA", "search-schema", { pattern: "pet" }],
+    ["GET PATH PARAMETERS", "get-path-parameters", { path: "/pets/{petId}", method: "get" }],
+    [
+      "GET RESPONSE SCHEMA",
+      "get-response-schema",
+      { path: "/pets/{petId}", method: "get", statusCode: "200" },
+    ],
+    ["LIST SECURITY SCHEMES", "list-security-schemes", {}],
+    [
+      "GET EXAMPLES",
+      "get-examples",
+      { type: "response", path: "/pets/{petId}", method: "get", statusCode: "200" },
+    ],
+  ];
 
-  // Get component schema
-  console.log("\n--- GET COMPONENT SCHEMA ---");
-  const component = await client.callTool({
-    name: "get-component",
-    arguments: {
-      type: "schemas",
-      name: "Pet",
-    },
-  });
-  console.log(component.content[0].text);
-
-  // Search schema
-  console.log("\n--- SEARCH SCHEMA ---");
-  const searchResults = await client.callTool({
-    name: "search-schema",
-    arguments: {
-      pattern: "pet",
-    },
-  });
-  console.log(searchResults.content[0].text);
-
-  // Get path parameters
-  console.log("\n--- GET PATH PARAMETERS ---");
-  const parameters = await client.callTool({
-    name: "get-path-parameters",
-    arguments: {
-      path: "/pets/{petId}",
-      method: "get",
-    },
-  });
-  console.log(parameters.content[0].text);
-
-  // Get response schema
-  console.log("\n--- GET RESPONSE SCHEMA ---");
-  const response = await client.callTool({
-    name: "get-response-schema",
-    arguments: {
-      path: "/pets/{petId}",
-      method: "get",
-      statusCode: "200",
-    },
-  });
-  console.log(response.content[0].text);
-
-  // List security schemes
-  console.log("\n--- LIST SECURITY SCHEMES ---");
-  const security = await client.callTool({
-    name: "list-security-schemes",
-    arguments: {},
-  });
-  console.log(security.content[0].text);
-} catch (error) {
-  console.error("Error during testing:", error);
-} finally {
-  // Close the connection
-  await client.close();
-  console.log("\nTests completed, disconnected from server.");
+  try {
+    for (const [title, name, args] of calls) {
+      console.log(`\n--- ${title} ---`);
+      const result = await client.callTool({ name, arguments: args });
+      console.log(result.content[0].text);
+      if (result.isError) {
+        failures++;
+        console.error(`FAILED: ${name} returned an error`);
+      }
+    }
+  } catch (error) {
+    failures++;
+    console.error("Error during testing:", error);
+  } finally {
+    await client.close();
+    console.log(`\nSuite "${label}" completed, disconnected from server.`);
+  }
 }
+
+// Single-file spec (regression) and split multi-file spec with a circular
+// Pet <-> Category reference (task 001)
+await runSuite("./sample-petstore.yaml", "single-file spec");
+await runSuite("./sample-petstore-split/openapi.yaml", "split spec with $refs");
+
+if (failures > 0) {
+  console.error(`\n${failures} tool call(s) failed.`);
+  process.exit(1);
+}
+console.log("\nAll tool calls succeeded in both suites.");

--- a/index.mjs
+++ b/index.mjs
@@ -18,29 +18,44 @@ if (args.includes("--help") || args.includes("-h")) {
 OpenAPI Schema Model Context Protocol Server
 
 Usage: 
-  node index.mjs [path/to/openapi.yaml]
+  node index.mjs [path-or-url]
 
 Arguments:
-  path/to/openapi.yaml  Path to the OpenAPI schema file (JSON or YAML) (optional)
-                       If not provided, defaults to openapi.yaml
+  path-or-url  Path to a local OpenAPI file (JSON or YAML), or URL of a remote schema (optional).
+               If not provided, defaults to openapi.yaml
 
 Examples:
   node index.mjs # Uses default openapi.yaml
   node index.mjs ../petstore.json # Uses petstore OpenAPI spec
   node index.mjs /absolute/path/to/api-schema.yaml
+  node index.mjs https://petstore3.swagger.io/api/v3/openapi.json
   `);
   process.exit(0);
 }
 
 const schemaArg = args[0];
 
+// True if the given string looks like an HTTP(S) URL
+const isUrl = (s) => typeof s === "string" && /^https?:\/\//i.test(s.trim());
+
 const loadSchema = async () => {
-  // Default to openapi.yaml if no argument provided
-  const schemaPath = resolve(schemaArg ?? "openapi.yaml");
+  // Default to openapi.yaml if no argument provided; URLs are passed through
+  // to SwaggerParser, which fetches them (and any relative $refs) over HTTP
+  const schemaInput = (schemaArg ?? "openapi.yaml").trim();
+  const schemaPath = isUrl(schemaInput) ? schemaInput : resolve(schemaInput);
 
   try {
-    // Parse and validate the OpenAPI document
-    return await SwaggerParser.validate(schemaPath, { validate: { schema: false } });
+    // Report validation problems but continue — a parseable doc is still usable
+    try {
+      await SwaggerParser.validate(schemaPath, { validate: { schema: false } });
+    } catch (validationError) {
+      console.error(`Warning: schema validation failed: ${validationError.message}`);
+    }
+
+    // Bundle external $ref files into a single document with internal refs only
+    // (#/components/...); full dereferencing would turn circular schemas into
+    // circular objects that toYaml cannot dump
+    return await SwaggerParser.bundle(schemaPath);
   } catch (error) {
     console.error(`Error loading schema: ${error.message}`);
     process.exit(1);
@@ -49,14 +64,22 @@ const loadSchema = async () => {
 
 const openApiDoc = await loadSchema();
 
-// Extract schema name from file path or from the OpenAPI info
+// Extract schema name from the OpenAPI info, or from the file path / URL
 const schemaName =
   openApiDoc.info?.title ||
   (schemaArg
-    ? schemaArg
-        .split("/")
-        .pop()
-        .replace(/\.(yaml|json)$/i, "")
+    ? (() => {
+        const s = schemaArg.trim();
+        if (isUrl(s)) {
+          try {
+            const base = new URL(s).pathname.split("/").filter(Boolean).pop() || "openapi";
+            return base.replace(/\.(yaml|yml|json)$/i, "") || "openapi";
+          } catch {
+            return "openapi";
+          }
+        }
+        return s.split("/").pop().replace(/\.(yaml|yml|json)$/i, "") || "openapi";
+      })()
     : "openapi");
 
 const server = new McpServer({
@@ -68,6 +91,32 @@ const server = new McpServer({
 // Helper to convert objects to YAML for better readability
 const toYaml = (obj) => yaml.dump(obj, { lineWidth: 100, noRefs: true });
 
+// Look up an internal JSON pointer (e.g. "#/components/schemas/Pet") in the bundled doc
+const resolvePointer = (pointer) =>
+  pointer
+    .slice(2)
+    .split("/")
+    .map((segment) => segment.replace(/~1/g, "/").replace(/~0/g, "~"))
+    .reduce((node, segment) => (node == null ? undefined : node[segment]), openApiDoc);
+
+// Follow a node's $ref chain (cycle-safe); returns the node itself if it is not a $ref
+const resolveRef = (node) => {
+  const seen = new Set();
+  while (
+    node &&
+    typeof node === "object" &&
+    typeof node.$ref === "string" &&
+    node.$ref.startsWith("#/") &&
+    !seen.has(node.$ref)
+  ) {
+    seen.add(node.$ref);
+    const target = resolvePointer(node.$ref);
+    if (target === undefined) return node;
+    node = target;
+  }
+  return node;
+};
+
 // List all API paths and operations
 server.tool(
   "list-endpoints",
@@ -75,7 +124,8 @@ server.tool(
   () => {
     const pathMap = {};
 
-    for (const [path, pathItem] of Object.entries(openApiDoc.paths || {})) {
+    for (const [path, rawPathItem] of Object.entries(openApiDoc.paths || {})) {
+      const pathItem = resolveRef(rawPathItem);
       // Get all HTTP methods for this path
       const methods = Object.keys(pathItem).filter((key) =>
         ["get", "post", "put", "delete", "patch", "options", "head"].includes(key.toLowerCase()),
@@ -108,7 +158,7 @@ server.tool(
   "Gets detailed information about a specific API endpoint",
   { path: z.string(), method: z.string() },
   ({ path, method }) => {
-    const pathItem = openApiDoc.paths?.[path];
+    const pathItem = resolveRef(openApiDoc.paths?.[path]);
     if (!pathItem) {
       return { content: [{ type: "text", text: `Path ${path} not found` }] };
     }
@@ -149,7 +199,7 @@ server.tool(
   "Gets the request body schema for a specific endpoint",
   { path: z.string(), method: z.string() },
   ({ path, method }) => {
-    const pathItem = openApiDoc.paths?.[path];
+    const pathItem = resolveRef(openApiDoc.paths?.[path]);
     if (!pathItem) {
       return { content: [{ type: "text", text: `Path ${path} not found` }] };
     }
@@ -159,7 +209,7 @@ server.tool(
       return { content: [{ type: "text", text: `Method ${method} not found for path ${path}` }] };
     }
 
-    const requestBody = operation.requestBody;
+    const requestBody = resolveRef(operation.requestBody);
     if (!requestBody) {
       return { content: [{ type: "text", text: `No request body defined for ${method} ${path}` }] };
     }
@@ -185,7 +235,7 @@ server.tool(
     statusCode: z.string().default("200"),
   },
   ({ path, method, statusCode }) => {
-    const pathItem = openApiDoc.paths?.[path];
+    const pathItem = resolveRef(openApiDoc.paths?.[path]);
     if (!pathItem) {
       return { content: [{ type: "text", text: `Path ${path} not found` }] };
     }
@@ -200,7 +250,7 @@ server.tool(
       return { content: [{ type: "text", text: `No responses defined for ${method} ${path}` }] };
     }
 
-    const response = responses[statusCode] || responses.default;
+    const response = resolveRef(responses[statusCode] || responses.default);
     if (!response) {
       return {
         content: [
@@ -229,18 +279,18 @@ server.tool(
   "Gets the parameters for a specific path",
   { path: z.string(), method: z.string().optional() },
   ({ path, method }) => {
-    const pathItem = openApiDoc.paths?.[path];
+    const pathItem = resolveRef(openApiDoc.paths?.[path]);
     if (!pathItem) {
       return { content: [{ type: "text", text: `Path ${path} not found` }] };
     }
 
-    let parameters = [...(pathItem.parameters || [])];
+    let parameters = (pathItem.parameters || []).map(resolveRef);
 
     // If method is specified, add method-specific parameters
     if (method) {
       const operation = pathItem[method.toLowerCase()];
       if (operation && operation.parameters) {
-        parameters = [...parameters, ...operation.parameters];
+        parameters = [...parameters, ...operation.parameters.map(resolveRef)];
       }
     }
 
@@ -315,7 +365,7 @@ server.tool(
       };
     }
 
-    const component = componentType[name];
+    const component = resolveRef(componentType[name]);
     if (!component) {
       return {
         content: [
@@ -343,7 +393,8 @@ server.tool("list-security-schemes", "Lists all available security schemes", () 
   const securitySchemes = openApiDoc.components?.securitySchemes || {};
   const result = {};
 
-  for (const [name, scheme] of Object.entries(securitySchemes)) {
+  for (const [name, rawScheme] of Object.entries(securitySchemes)) {
+    const scheme = resolveRef(rawScheme);
     result[name] = {
       type: scheme.type,
       description: scheme.description,
@@ -393,14 +444,15 @@ server.tool(
         };
       }
 
-      const operation = openApiDoc.paths?.[path]?.[method.toLowerCase()];
+      const operation = resolveRef(openApiDoc.paths?.[path])?.[method.toLowerCase()];
       if (!operation) {
         return {
           content: [{ type: "text", text: `Operation ${method.toUpperCase()} ${path} not found` }],
         };
       }
 
-      if (!operation.requestBody?.content) {
+      const requestBody = resolveRef(operation.requestBody);
+      if (!requestBody?.content) {
         return {
           content: [
             { type: "text", text: `No request body defined for ${method.toUpperCase()} ${path}` },
@@ -409,7 +461,7 @@ server.tool(
       }
 
       const examples = {};
-      for (const [contentType, content] of Object.entries(operation.requestBody.content)) {
+      for (const [contentType, content] of Object.entries(requestBody.content)) {
         if (content.examples) {
           examples[contentType] = content.examples;
         } else if (content.example) {
@@ -440,7 +492,7 @@ server.tool(
         };
       }
 
-      const operation = openApiDoc.paths?.[path]?.[method.toLowerCase()];
+      const operation = resolveRef(openApiDoc.paths?.[path])?.[method.toLowerCase()];
       if (!operation) {
         return {
           content: [{ type: "text", text: `Operation ${method.toUpperCase()} ${path} not found` }],
@@ -455,9 +507,9 @@ server.tool(
         };
       }
 
-      const responseObj = statusCode
-        ? operation.responses[statusCode]
-        : Object.values(operation.responses)[0];
+      const responseObj = resolveRef(
+        statusCode ? operation.responses[statusCode] : Object.values(operation.responses)[0],
+      );
       if (!responseObj) {
         return {
           content: [
@@ -510,7 +562,7 @@ server.tool(
         };
       }
 
-      const component = openApiDoc.components?.[componentType]?.[componentName];
+      const component = resolveRef(openApiDoc.components?.[componentType]?.[componentName]);
       if (!component) {
         return {
           content: [
@@ -566,7 +618,7 @@ server.tool(
       }
 
       // Search operations within paths
-      const pathItem = openApiDoc.paths[path];
+      const pathItem = resolveRef(openApiDoc.paths[path]);
       for (const method of ["get", "post", "put", "delete", "patch", "options", "head"]) {
         const operation = pathItem[method];
         if (!operation) continue;
@@ -580,7 +632,8 @@ server.tool(
         }
 
         // Search parameters
-        for (const param of operation.parameters || []) {
+        for (const rawParam of operation.parameters || []) {
+          const param = resolveRef(rawParam);
           if (searchRegex.test(param.name || "") || searchRegex.test(param.description || "")) {
             results.parameters.push(`${param.name} (${method.toUpperCase()} ${path})`);
           }
@@ -593,7 +646,8 @@ server.tool(
     for (const [type, typeObj] of Object.entries(components)) {
       if (!typeObj || typeof typeObj !== "object") continue;
 
-      for (const [name, component] of Object.entries(typeObj)) {
+      for (const [name, rawComponent] of Object.entries(typeObj)) {
+        const component = resolveRef(rawComponent);
         if (searchRegex.test(name) || searchRegex.test(component.description || "")) {
           results.components.push(`${type}.${name}`);
         }
@@ -601,7 +655,8 @@ server.tool(
     }
 
     // Search security schemes
-    for (const [name, scheme] of Object.entries(components.securitySchemes || {})) {
+    for (const [name, rawScheme] of Object.entries(components.securitySchemes || {})) {
+      const scheme = resolveRef(rawScheme);
       if (searchRegex.test(name) || searchRegex.test(scheme.description || "")) {
         results.securitySchemes.push(name);
       }

--- a/sample-petstore-split/components/schemas/Category.yaml
+++ b/sample-petstore-split/components/schemas/Category.yaml
@@ -1,0 +1,10 @@
+type: object
+description: Pet category with a circular reference back to Pet (mascot)
+required:
+  - name
+properties:
+  name:
+    type: string
+    description: Category name
+  mascot:
+    $ref: './Pet.yaml'

--- a/sample-petstore-split/components/schemas/Error.yaml
+++ b/sample-petstore-split/components/schemas/Error.yaml
@@ -1,0 +1,12 @@
+type: object
+required:
+  - code
+  - message
+properties:
+  code:
+    type: integer
+    format: int32
+    description: Error code
+  message:
+    type: string
+    description: Error message

--- a/sample-petstore-split/components/schemas/NewPet.yaml
+++ b/sample-petstore-split/components/schemas/NewPet.yaml
@@ -1,0 +1,9 @@
+type: object
+required:
+  - name
+properties:
+  name:
+    type: string
+    description: Name of the pet
+  category:
+    $ref: './Category.yaml'

--- a/sample-petstore-split/components/schemas/Pet.yaml
+++ b/sample-petstore-split/components/schemas/Pet.yaml
@@ -1,0 +1,22 @@
+type: object
+required:
+  - id
+  - name
+properties:
+  id:
+    type: integer
+    format: int64
+    description: Unique identifier for the pet
+  name:
+    type: string
+    description: Name of the pet
+  status:
+    type: string
+    description: Status of the pet
+    enum:
+      - available
+      - pending
+      - sold
+    default: available
+  category:
+    $ref: './Category.yaml'

--- a/sample-petstore-split/components/schemas/PetsResponse.yaml
+++ b/sample-petstore-split/components/schemas/PetsResponse.yaml
@@ -1,0 +1,18 @@
+type: object
+required:
+  - pets
+  - total
+properties:
+  pets:
+    type: array
+    items:
+      $ref: './Pet.yaml'
+  total:
+    type: integer
+    description: Total number of pets
+  limit:
+    type: integer
+    description: Limit used in the request
+  offset:
+    type: integer
+    description: Offset used in the request

--- a/sample-petstore-split/openapi.yaml
+++ b/sample-petstore-split/openapi.yaml
@@ -1,0 +1,32 @@
+openapi: 3.0.0
+info:
+  title: Petstore API (split)
+  version: 1.0.0
+  description: Sample API split across multiple files via $ref pointers
+servers:
+  - url: https://petstore.example.com/api/v1
+paths:
+  /pets:
+    $ref: './paths/pets.yaml'
+  /pets/{petId}:
+    $ref: './paths/pets_petId.yaml'
+components:
+  schemas:
+    Pet:
+      $ref: './components/schemas/Pet.yaml'
+    Category:
+      $ref: './components/schemas/Category.yaml'
+    NewPet:
+      $ref: './components/schemas/NewPet.yaml'
+    PetsResponse:
+      $ref: './components/schemas/PetsResponse.yaml'
+    Error:
+      $ref: './components/schemas/Error.yaml'
+  securitySchemes:
+    ApiKeyAuth:
+      type: apiKey
+      in: header
+      name: X-API-Key
+      description: API key for authorization
+security:
+  - ApiKeyAuth: []

--- a/sample-petstore-split/paths/pets.yaml
+++ b/sample-petstore-split/paths/pets.yaml
@@ -1,0 +1,50 @@
+get:
+  summary: List all pets
+  description: Returns all pets from the system
+  operationId: listPets
+  tags:
+    - pets
+  parameters:
+    - name: limit
+      in: query
+      description: Maximum number of pets to return
+      required: false
+      schema:
+        type: integer
+        format: int32
+        minimum: 1
+        maximum: 100
+        default: 20
+  responses:
+    '200':
+      description: A paged array of pets
+      content:
+        application/json:
+          schema:
+            $ref: '../components/schemas/PetsResponse.yaml'
+post:
+  summary: Create a pet
+  description: Creates a new pet in the store
+  operationId: createPet
+  tags:
+    - pets
+  requestBody:
+    description: Pet to add to the store
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: '../components/schemas/NewPet.yaml'
+  responses:
+    '201':
+      description: Pet created
+      content:
+        application/json:
+          schema:
+            $ref: '../components/schemas/Pet.yaml'
+    '400':
+      description: Invalid input
+      content:
+        application/json:
+          schema:
+            $ref: '../components/schemas/Error.yaml'

--- a/sample-petstore-split/paths/pets_petId.yaml
+++ b/sample-petstore-split/paths/pets_petId.yaml
@@ -1,0 +1,50 @@
+get:
+  summary: Get a pet by ID
+  description: Returns a single pet by ID
+  operationId: getPetById
+  tags:
+    - pets
+  parameters:
+    - name: petId
+      in: path
+      description: ID of pet to return
+      required: true
+      schema:
+        type: integer
+        format: int64
+  responses:
+    '200':
+      description: Expected response to a valid request
+      content:
+        application/json:
+          schema:
+            $ref: '../components/schemas/Pet.yaml'
+    '404':
+      description: Pet not found
+      content:
+        application/json:
+          schema:
+            $ref: '../components/schemas/Error.yaml'
+delete:
+  summary: Delete a pet
+  description: Deletes a pet by ID
+  operationId: deletePet
+  tags:
+    - pets
+  parameters:
+    - name: petId
+      in: path
+      description: ID of pet to delete
+      required: true
+      schema:
+        type: integer
+        format: int64
+  responses:
+    '204':
+      description: Pet deleted
+    '404':
+      description: Pet not found
+      content:
+        application/json:
+          schema:
+            $ref: '../components/schemas/Error.yaml'


### PR DESCRIPTION
This PR makes the server work with real-world OpenAPI specs in two ways.

## 1. Split/multi-file specs and circular references

Specs split across multiple files via `$ref` pointers loaded, but any **circular schema** (e.g. `Pet -> Category -> Pet`, very common in split specs) crashed tool calls with `Maximum call stack size exceeded`: `SwaggerParser.validate()` fully dereferences the document into circular JS objects, which `yaml.dump({ noRefs: true })` cannot serialize.

- Load schemas with `SwaggerParser.bundle()` instead: external files are inlined, cross-references stay as internal `#/components/...` pointers, so circular schemas remain representable.
- Keep a `validate()` pass for diagnostics only; a parseable spec that fails validation warns on stderr instead of exiting.
- Add cycle-safe `resolveRef`/`resolvePointer` helpers; all tool handlers resolve internal `$refs` on the nodes they read (path items, request bodies, responses, parameters, components, security schemes).
- Behavior change: responses keep internal `$ref` pointers instead of inlining schemas (documented in README; expand via `get-component`).
- New `sample-petstore-split/` fixture with circular `Pet <-> Category` refs; `example-usage.mjs` now runs all 10 tools against both fixtures and exits non-zero on tool errors.

## 2. Remote URL schema sources

Incorporates #4 by @ppspps824 (credited as co-author), adapted to the bundle-based loader: URLs are passed straight to SwaggerParser (which also fetches relative `$refs` over HTTP), schema name is derived from the URL pathname, help text and README updated.

## Testing

`npm test` runs the full 10-tool suite against both the single-file and the split fixture: "All tool calls succeeded in both suites." Remote loading smoke-tested against https://petstore3.swagger.io/api/v3/openapi.json.